### PR TITLE
feat(snap): add vault secret-token content interface

### DIFF
--- a/snap/local/runtime-helpers/bin/service-wrapper.sh
+++ b/snap/local/runtime-helpers/bin/service-wrapper.sh
@@ -10,5 +10,11 @@ if [ ! -z "$profile" ]; then
     fi
 fi
 
+# disable TLS usage
+export SECRETSTORE_PROTOCOL='http'
+export SECRETSTORE_ROOTCACERTPATH=""
+export SECRETSTOREEXCLUSIVE_PROTOCOL='http'
+export SECRETSTOREEXCLUSIVE_ROOTCACERTPATH=""
+
 $SNAP/bin/app-service-configurable -confdir $SNAP_DATA/config/res $PROFILE_OPT -cp -r
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,12 +32,22 @@ confinement: strict
 # geneva release is epoch 3
 epoch: 3
 
+slots:
+  edgex-secretstore-token:
+    interface: content
+    content: edgex-secretstore-token
+    source:
+      write: [$SNAP_DATA/edgex-application-service]
+
 apps:
   app-service-configurable:
     adapter: full
     command: bin/service-wrapper.sh
     command-chain:
       - bin/startup-env-var.sh
+    environment:
+      SecretStore_TokenFile: $SNAP_DATA/edgex-application-service/secrets-token.json
+      SecretStoreExclusive_TokenFile: $SNAP_DATA/edgex-application-service/secrets-token.json
     daemon: simple
     plugs: [network, network-bind]
 


### PR DESCRIPTION
This content interface provides a mechanism for this snap to
consume a shared vault secret token from the edgexfoundry snap
in order for the service in this snap to access the secret-store.
Note, in this case this snap defines a slot instead of a plug to
allow this snap to create a service-specific directory under
$SNAP_DATA/secrets in the edgexfoundry snap.

Signed-off-by: Tony Espy <espy@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [NA] Docs have been added / updated (for bug fixes / features)

<!-- If your build fails due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/master/.github/CONTRIBUTING.md -->

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
This PR adds a content interface to the snap which allows it to consume a vault secret token from the edgexfoundry snap when the content interface is connected.

<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number:


## What is the new behavior?


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?

## Other information