### PR TITLE
fix(snap): fix rich config hook bug

### DIFF
--- a/hooks/go.mod
+++ b/hooks/go.mod
@@ -1,5 +1,5 @@
 module github.com/canonical/app-service-configurable/hooks
 
-require github.com/canonical/edgex-snap-hooks v0.5.0
+require github.com/canonical/edgex-snap-hooks v0.9.0
 
 go 1.15


### PR DESCRIPTION
This commit changes a bug that can occur when
HandleEdgeXConfig is passed a nil extraConf map.
Updating to v0.9.0 of edgex-snap-hooks resolves
the issue.

Signed-off-by: Tony Espy <espy@canonical.com>
