### PR TITLE
fix(snap): move autostart logic to config hook

### DIFF
--- a/snap/local/runtime-helpers/bin/debug.sh
+++ b/snap/local/runtime-helpers/bin/debug.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -ex
-
-debug=$(snapctl get debug)
-logger "app-service-config: debug: $debug"
-
-autostart=$(snapctl get autostart)
-logger "app-service-config: autostart: $autostart"
-
-exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,11 +32,6 @@ confinement: strict
 # geneva release is epoch 3
 epoch: 3
 
-hooks:
-  install:
-    command-chain:
-      - bin/debug.sh
-
 plugs:
   # This content plug allows new profiles to be added to the service via a config
   # or gadget snap that defines a matching slot.


### PR DESCRIPTION
See the commit message for details on what and why this change was made. Hopefully this is the last change to the hooks for this release of asc.

Here's what I've tested so far without actually creating an actual image:

1. install edgexfoundry from beta
2. install this snap built locally
3. connect the vault token content interface:

`$ sudo snap connect edgexfoundry:edgex-secretstore-token edgex-app-service-configurable:edgex-secretstore-token`

4. set autostart=true; this results in an error because no profile has been configured yet
5. set profile=http-export; this results in the profile being started & enabled
